### PR TITLE
Fix CDN convert using URI.js

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,17 +1,26 @@
 "use strict";
 const AWS = require('aws-sdk');
-const crypto = require('crypto')
+const URI = require('urijs');
+const crypto = require('crypto');
 
 class FileLocationConverter {
-  static getKey(config, file) {
-    return `${config.directory ? `${config.directory}/` : ''}${file.hash}${file.ext}`
+  constructor(config) {
+    this.config = config;
   }
 
-  static getUrl(config, data) {
-    if (config.cdn)
-      return data.Location.replace(`${config.space}.${config.endpoint}`, config.cdn);
-    else
-      return data.Location
+  getKey(file) {
+    const filename = `${file.hash}${file.ext}`;
+    if (!this.config.directory) return filename;
+    return `${this.config.directory}/${filename}`;
+  }
+
+  getUrl(data) {
+    if (!this.config.cdn) return data.Location;
+    var parts = {};
+    URI.parseHost(this.config.cdn, parts);
+    parts.protocol = "https"; // Force https
+    parts.path = data.Key;
+    return URI.build(parts);
   }
 }
 
@@ -45,10 +54,11 @@ module.exports = {
     }
   },
   init: config => {
-    const spacesEndpoint = new AWS.Endpoint(config.endpoint);
+    const endpoint = new AWS.Endpoint(config.endpoint);
+    const converter = new FileLocationConverter(config);
 
     const S3 = new AWS.S3({
-      endpoint: spacesEndpoint,
+      endpoint: endpoint,
       accessKeyId: config.key,
       secretAccessKey: config.secret,
       params: {
@@ -65,7 +75,7 @@ module.exports = {
 
         //--- Upload the file into the space (technically the S3 Bucket)
         S3.upload({
-            Key: FileLocationConverter.getKey(config, file),
+            Key: converter.getKey(file),
             Body: Buffer.from(file.buffer, "binary"),
             ContentType: file.mime
           },
@@ -73,8 +83,7 @@ module.exports = {
           //--- Callback handler
           (err, data) => {
             if (err) return reject(err);
-            file.url = FileLocationConverter.getUrl(config, data);
-
+            file.url = converter.getUrl(data);
             resolve();
           });
 
@@ -85,7 +94,7 @@ module.exports = {
           //--- Delete the file from the space
           S3.deleteObject({
               Bucket: config.bucket,
-              Key: FileLocationConverter.getKey(config, file),
+              Key: converter.getKey(file),
             },
 
             //--- Callback handler
@@ -95,7 +104,6 @@ module.exports = {
             })
         }
       )
-
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,139 @@
 {
   "name": "strapi-provider-upload-do",
   "version": "3.5.4",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "3.5.4",
+      "license": "MIT",
+      "dependencies": {
+        "aws-sdk": "2.388.0",
+        "urijs": "^1.19.6"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 6.0.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.388.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.388.0.tgz",
+      "integrity": "sha512-2yycFVn90H61R3vbE+4Yqn8AEOS88oOE1wUsm6aUhsk+i/Y707a85C166gKuE3+if4y8IS5qqQJiX+HUtF0KNw==",
+      "dependencies": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "node_modules/buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/urijs": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
     "aws-sdk": {
       "version": "2.388.0",
@@ -69,6 +200,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "urijs": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw=="
     },
     "url": {
       "version": "0.10.3",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "main": "./lib",
   "dependencies": {
-    "aws-sdk": "2.388.0"
+    "aws-sdk": "2.388.0",
+    "urijs": "^1.19.6"
   },
   "strapi": {
     "isProvider": true


### PR DESCRIPTION
# Provide a more robust URI conversion when using CDN.

For some mime (like audio) the `Location` format differs, and so the URL conversion using `data.Location.replace` fails.
By using [URI.js](https://medialize.github.io/URI.js/), we can easily enforce the URL to the following format:
`https//<config.cdn>/<object.key>`