### PR TITLE
Add missing upload stream function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,25 +68,37 @@ module.exports = {
       },
     });
 
+    const upload = file => new Promise((resolve, reject) => {
+      //--- Compute the file key.
+      file.hash = crypto.createHash('md5').update(file.hash).digest("hex");
+
+      //--- Upload the file into the space (technically the S3 Bucket)
+      S3.upload({
+          Key: converter.getKey(file),
+          Body: Buffer.from(file.buffer, "binary"),
+          ContentType: file.mime
+        },
+
+        //--- Callback handler
+        (err, data) => {
+          if (err) return reject(err);
+          file.url = converter.getUrl(data);
+          resolve();
+        });
+    });
+
     return {
-      upload: file => new Promise((resolve, reject) => {
-        //--- Compute the file key.
-        file.hash = crypto.createHash('md5').update(file.hash).digest("hex");
+      upload,
 
-        //--- Upload the file into the space (technically the S3 Bucket)
-        S3.upload({
-            Key: converter.getKey(file),
-            Body: Buffer.from(file.buffer, "binary"),
-            ContentType: file.mime
-          },
+      uploadStream: file => new Promise((resolve, reject) => {
+        const _buf = [];
 
-          //--- Callback handler
-          (err, data) => {
-            if (err) return reject(err);
-            file.url = converter.getUrl(data);
-            resolve();
-          });
-
+        file.stream.on('data', chunk => _buf.push(chunk));
+        file.stream.on('end', () => {
+          file.buffer = Buffer.concat(_buf);
+          resolve(upload(file));
+        });
+        file.stream.on('error', err => reject(err));
       }),
 
       delete: file => new Promise((resolve, reject) => {


### PR DESCRIPTION
Function `uploadStream` is required in the strapi v4 (ex. logo upload)