### PR TITLE
Remove buffer from file

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -83,6 +83,7 @@ module.exports = {
         (err, data) => {
           if (err) return reject(err);
           file.url = converter.getUrl(data);
+          delete file.buffer;
           resolve();
         });
     });


### PR DESCRIPTION
Currently the buffer is never removed from the file object causing strapi to store the buffer in the database.

Here an example of a response (located in the formats field of a media response)
<img width="792" alt="Screenshot 2022-12-19 at 00 17 33" src="https://user-images.githubusercontent.com/35739042/208324592-351157e9-46a0-4282-a789-f6fd7264fe1c.png">
